### PR TITLE
zserio-mqtt: pass topic name as parameter in pubsub functions

### DIFF
--- a/compiler/extensions/cpp/freemarker/Topic.cpp.ftl
+++ b/compiler/extensions/cpp/freemarker/Topic.cpp.ftl
@@ -49,11 +49,11 @@ void ${name}::unsubscribe(
     }
 }
 
-void ${name}::onMessageAvailable(const uint8_t * msgData, size_t  size) const
+void ${name}::onMessageAvailable(const std::string& topic, const uint8_t * msgData, size_t  size) const
 {
     auto pl = dataToSzerio<${valueTypeName}>(msgData, size);
     for (auto& sub: subscribers_)
-        sub.second(pl);
+        sub.second(topic, pl);
 }
 
 <@namespace_end package.path/>

--- a/compiler/extensions/cpp/freemarker/Topic.h.ftl
+++ b/compiler/extensions/cpp/freemarker/Topic.h.ftl
@@ -32,12 +32,12 @@ public:
     void publish(zserio::PubSubClient& pub, ${valueTypeName} &pl, int qualityOfService, bool retain) const;
 
     /** Subscribe to this topic get notifications if payload is available */
-    using OnPayloadAvailable = std::function<void(const ${valueTypeName}& pl)>;
+    using OnPayloadAvailable = std::function<void(const std::string& topic, const ${valueTypeName}& pl)>;
     zserio::PubSubClient::SubscriptionId subscribe(zserio::PubSubClient& sub, const OnPayloadAvailable& callback);
     void unsubscribe(zserio::PubSubClient& sub, zserio::PubSubClient::SubscriptionId id);
 
     /** Gets invoked when message with compatible topic is available */
-    void onMessageAvailable(const uint8_t *msgData, size_t size) const override;
+    void onMessageAvailable(const std::string& topic, const uint8_t *msgData, size_t size) const override;
 
 private:
     std::map<zserio::PubSubClient::SubscriptionId, OnPayloadAvailable> subscribers_;

--- a/compiler/extensions/cpp/runtime/src/zserio/MqttPubSubClient.cpp
+++ b/compiler/extensions/cpp/runtime/src/zserio/MqttPubSubClient.cpp
@@ -224,7 +224,7 @@ struct MqttPubSubClient::Impl
         for (auto& t: m_topics)
         {
             if (t->matches(topic))
-                t->onMessageAvailable(msgData, msgSize);
+                t->onMessageAvailable(topic, msgData, msgSize);
         }
     }
 

--- a/compiler/extensions/cpp/runtime/src/zserio/Topic.h
+++ b/compiler/extensions/cpp/runtime/src/zserio/Topic.h
@@ -29,7 +29,7 @@ public:
     std::string unboundTopic() const;
 
     /** Gets called when message with compatible topic has arrived */
-    virtual void onMessageAvailable(const uint8_t* msgData, size_t size) const = 0;
+    virtual void onMessageAvailable(const std::string& topic, const uint8_t* msgData, size_t msgSize) const = 0;
 
     /** Activate subscription for this topic at the provided PubSubClient */
     PubSubClient::SubscriptionId subscribe(PubSubClient& sub);


### PR DESCRIPTION
Changes to the onMessageAvailable() and subscribe() function signatures to pass the exact topic name for a received message. Complementing changes to kettcar are in the branch mqtt-diagnostics.