### PR TITLE
Make sure that the extern container does not propagate any prior offset

### DIFF
--- a/compiler/extensions/cpp/freemarker/CompoundField.inc.ftl
+++ b/compiler/extensions/cpp/freemarker/CompoundField.inc.ftl
@@ -652,7 +652,7 @@ ${I}            break;
 ${I}        _${field.name}_SKIP += 8;
 ${I}    }
 ${I}    _endBitPosition += _${field.name}_SKIP;
-${I}    _endBitPosition = m_${field.name}_INITIALIZEOFFSET(_endBitPosition);
+${I}    _endBitPosition = m_${field.name}_INITIALIZEOFFSET(0);
 ${I}}
     <#else>
 ${I}_endBitPosition = <@compound_get_field field/>.initializeOffsets(_endBitPosition);


### PR DESCRIPTION
Externs are generally deserialised independently from their container, after their type has been determined by the application.

This means, they are used with a separate BitStreamReader, where offset 0 is the beginning of the external blob.

This must be considered during serialisation, in particular `initializeOffsets()`: The external must not adopt the offset from it's parent container.