### PR TITLE
Test case for nested template instantiation of different package

### DIFF
--- a/test/language/templates/CMakeLists.txt
+++ b/test/language/templates/CMakeLists.txt
@@ -55,13 +55,17 @@ set(ZSERIO_GENERATED_SOURCES
     ${ZSERIO_GEN_DIR}/templates/expression_full_template_argument/FullTemplateArgument_templates_expression_full_template_argument_color_Color.cpp
     ${ZSERIO_GEN_DIR}/templates/expression_full_template_argument/FullTemplateArgument_templates_expression_full_template_argument_color_Color.h
 
-    ${ZSERIO_GEN_DIR}/templates/instantiate_imported/pkg
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/Test_string.cpp
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/Test_string.h
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/InstantiateImported.cpp
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/InstantiateImported.h
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/pkg/U32.cpp
     ${ZSERIO_GEN_DIR}/templates/instantiate_imported/pkg/U32.h
+
+    ${ZSERIO_GEN_DIR}/templates/instantiate_imported_nested/Nested_uint32.cpp
+    ${ZSERIO_GEN_DIR}/templates/instantiate_imported_nested/Nested_uint32.h
+    ${ZSERIO_GEN_DIR}/templates/instantiate_imported_nested/pkg/U32.cpp
+    ${ZSERIO_GEN_DIR}/templates/instantiate_imported_nested/pkg/U32.h
 
     ${ZSERIO_GEN_DIR}/templates/instantiate_nested_template/TStr.cpp
     ${ZSERIO_GEN_DIR}/templates/instantiate_nested_template/TStr.h
@@ -339,6 +343,7 @@ add_test_sources(
     ${ZSERIO_CPP_DIR}/ExpressionEnumTemplateArgumentConflictTest.cpp
     ${ZSERIO_CPP_DIR}/ExpressionFullTemplateArgumentTest.cpp
     ${ZSERIO_CPP_DIR}/InstantiateImportedTest.cpp
+    ${ZSERIO_CPP_DIR}/InstantiateImportedNestedTest.cpp
     ${ZSERIO_CPP_DIR}/InstantiateNestedTemplateTest.cpp
     ${ZSERIO_CPP_DIR}/InstantiateNotImportedTest.cpp
     ${ZSERIO_CPP_DIR}/InstantiateOnlyNestedTest.cpp

--- a/test/language/templates/cpp/InstantiateImportedNestedTest.cpp
+++ b/test/language/templates/cpp/InstantiateImportedNestedTest.cpp
@@ -1,0 +1,26 @@
+#include "gtest/gtest.h"
+
+#include "templates/instantiate_imported_nested/pkg/U32.h"
+
+namespace templates
+{
+namespace instantiate_imported_nested
+{
+
+TEST(InstantiateImportedNestedTest, readWrite)
+{
+    pkg::U32 u32{13u};
+
+    zserio::BitStreamWriter writer;
+    u32.write(writer);
+    size_t bufferSize = 0u;
+    const auto buffer = writer.getWriteBuffer(bufferSize);
+
+    zserio::BitStreamReader reader(buffer, bufferSize);
+    pkg::U32 readU32(reader);
+
+    ASSERT_EQ(u32, readU32);
+}
+
+} // namespace instantiate_imported_nested
+} // namespace templates

--- a/test/language/templates/zs/templates.zs
+++ b/test/language/templates/zs/templates.zs
@@ -8,6 +8,7 @@ import templates.expression_enum_template_argument_conflict.*;
 import templates.expression_full_template_argument.*;
 import templates.function_templated_return_type.*;
 import templates.instantiate_imported.*;
+import templates.instantiate_imported_nested.*;
 import templates.instantiate_nested_template.*;
 import templates.instantiate_not_imported.*;
 import templates.instantiate_only_nested.*;

--- a/test/language/templates/zs/templates/instantiate_imported_nested.zs
+++ b/test/language/templates/zs/templates/instantiate_imported_nested.zs
@@ -1,0 +1,13 @@
+package templates.instantiate_imported_nested;
+
+import templates.instantiate_imported_nested.pkg.*;
+
+struct Nested<T>
+{
+    T value;
+};
+
+struct Test<T>
+{
+    Nested<T> value;
+};

--- a/test/language/templates/zs/templates/instantiate_imported_nested/pkg.zs
+++ b/test/language/templates/zs/templates/instantiate_imported_nested/pkg.zs
@@ -1,0 +1,5 @@
+package templates.instantiate_imported_nested.pkg;
+
+import templates.instantiate_imported_nested.Test;
+
+instantiate Test<uint32> U32;


### PR DESCRIPTION
Added a C++ unit-test for testing the code-generation of nested zserio
templated structs of different packages. Package A instantiates a nested
templated struct of package B.